### PR TITLE
fix(frontend): unify dashboard background color with the rest of the UI (#32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Cleaned up sidebar header: removed the "Edge Mining" text label and the username placeholder, left-aligned the logo with the sidebar menu items, and refined the green glow to originate from the logo area (#33).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Unified the dashboard background color with the rest of the interface: the main content area now uses the same grey (`base-100`) as the sidebar, cards, top bar, and bottom bar instead of a lighter `base-200`, reinforcing the flat visual style (#32).
+
 ### Changed
 
 - Cleaned up sidebar header: removed the "Edge Mining" text label and the username placeholder, left-aligned the logo with the sidebar menu items, and refined the green glow to originate from the logo area (#33).

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -47,7 +47,7 @@ const toastClass = computed(() => {
       </div>
     </div>
 
-    <div class="drawer-content flex flex-col h-screen overflow-hidden bg-base-200">
+    <div class="drawer-content flex flex-col h-screen overflow-hidden bg-base-100">
       <TopBar :show-drawer="showDrawer" @toggle-drawer="showDrawer = !showDrawer" />
       <main class="flex-1 overflow-y-auto p-5">
         <RouterView />

--- a/frontend/src/components/SidebarMenu.vue
+++ b/frontend/src/components/SidebarMenu.vue
@@ -55,15 +55,8 @@ const isHomeLoadsActive = computed(() =>
 
     <div class="navbar p-4 h-full relative z-10">
       <div class="flex-none h-full">
-        <div class="flex flex-row items-center py-4 mb-2">
-          <VectorIcon name="logo" class="inline-block size-9" />
-          <div class="flex flex-col ml-3">
-            <span
-              class="text-[10px] uppercase tracking-wider text-base-300 font-medium"
-              >Edge Mining</span
-            >
-            <!-- <span class="text-sm font-medium">Satoshi Nakamoto</span> -->
-          </div>
+        <div class="flex items-center py-4 mb-2 pl-3">
+          <VectorIcon name="logo" class="size-9" />
         </div>
 
         <ul class="menu px-0 w-full gap-0.5">
@@ -305,13 +298,13 @@ const isHomeLoadsActive = computed(() =>
   top: 0;
   left: 0;
   width: 100%;
-  height: 12rem;
+  height: 14rem;
   background: radial-gradient(
-    ellipse 120% 100% at 50% -30%,
-    oklch(75% 0.25 130 / 0.3) 0%,
-    oklch(75% 0.2 130 / 0.15) 30%,
-    oklch(75% 0.15 130 / 0.05) 50%,
-    transparent 80%
+    ellipse 90% 70% at 18% 12%,
+    oklch(75% 0.25 130 / 0.28) 0%,
+    oklch(75% 0.2 130 / 0.14) 30%,
+    oklch(75% 0.15 130 / 0.05) 55%,
+    transparent 85%
   );
   pointer-events: none;
   z-index: 0;


### PR DESCRIPTION
## Summary

Fixes #32.

The dashboard background appeared in a slightly lighter shade of grey than the sidebar, cards, and tables, breaking the flat, modern look of the UI.

The main content area (`drawer-content` in `App.vue`) used `bg-base-200` (oklch 35%), while the sidebar, cards, top bar, and bottom bar all use `bg-base-100` (oklch 25%). Switching the content area to `bg-base-100` unifies the whole interface to a single background tone.

## Changes

- `frontend/src/App.vue`: `drawer-content` background `bg-base-200` → `bg-base-100`.
- `CHANGELOG.md`: added entry under `Fixed`.

## Notes

Cards remain distinguishable thanks to their border (`border-base-300/40`), consistent with the requested flat style.