### PR TITLE
feat: manage system settings (timezone, location, scheduler interval) from the app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,13 +12,6 @@
 # Application Settings
 LOG_LEVEL=INFO
 
-# Set your timezone (e.g., Europe/Rome, America/New_York)
-TIMEZONE=Europe/Rome
-
-# Coordinates for location-based services (e.g., weather forecasting or Sun properties)
-LATITUDE=41.9028
-LONGITUDE=12.4964
-
 # Persistence Settings
 # Adapter type: "in_memory", "sqlite", "sqlalchemy"
 PERSISTENCE_ADAPTER=sqlalchemy
@@ -45,6 +38,3 @@ YAML_POLICIES_DIR=data/policies
 
 # API Settings
 API_PORT=8001
-
-# Scheduler
-SCHEDULER_INTERVAL_SECONDS=5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **System settings management** — timezone, location (latitude/longitude) and the optimization scheduler interval are now user-editable from the app instead of environment variables:
+- **System settings management** — timezone, location (latitude/longitude) and the optimization scheduler interval are now user-editable from the app instead of environment variables (#54):
   - `SystemConfiguration` value object and typed `ConfigurationService.get_system_configuration()` / `update_system_configuration()`, persisted through the existing settings store
   - REST endpoints `GET` / `PUT /api/v1/system/settings`
   - New "System" settings page in the frontend, with the timezone list sourced from the browser and an interactive dark map (Leaflet) to pick the location by dragging a marker or clicking, using the Edge Mining logo as the marker
@@ -51,11 +51,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Miner controller add/edit form now uses the shared schema-driven configuration form, so Home Assistant controllers (e.g. generic socket) benefit from entity/unit pairing and the unit segmented controls like the other forms (#17, #18).
 - Cleaned up sidebar header: removed the "Edge Mining" text label and the username placeholder, left-aligned the logo with the sidebar menu items, and refined the green glow to originate from the logo area (#33).
 - `MinerActionService`: extracted shared `_read_miner_info` / `_read_miner_limits`helpers and a `_temp_miner_for_controller` builder, reused by the miner- and controller-level info/limits/details reads.
-- System configuration (timezone, latitude, longitude, scheduler interval) now lives in the database and is managed from the app; the values are seeded from defaults on first run.
+- System configuration (timezone, latitude, longitude, scheduler interval) now lives in the database and is managed from the app; the values are seeded from defaults on first run (#54).
 
 ### Removed
 
-- Environment variables `TIMEZONE`, `LATITUDE`, `LONGITUDE` and `SCHEDULER_INTERVAL_SECONDS` are no longer read; these settings are now managed from the System settings page. Existing values in `.env` are ignored.
+- Environment variables `TIMEZONE`, `LATITUDE`, `LONGITUDE` and `SCHEDULER_INTERVAL_SECONDS` are no longer read; these settings are now managed from the System settings page. Existing values in `.env` are ignored (#54).
 
 ## [Pre-Release Rev3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **System settings management** — timezone, location (latitude/longitude) and the optimization scheduler interval are now user-editable from the app instead of environment variables:
+  - `SystemConfiguration` value object and typed `ConfigurationService.get_system_configuration()` / `update_system_configuration()`, persisted through the existing settings store
+  - REST endpoints `GET` / `PUT /api/v1/system/settings`
+  - New "System" settings page in the frontend, with the timezone list sourced from the browser and an interactive dark map (Leaflet) to pick the location by dragging a marker or clicking, using the Edge Mining logo as the marker
+  - Changes are applied at runtime without a restart: a `SystemConfigurationUpdated` event refreshes the application timezone and the Sun-calculation location, and reschedules the evaluation job with the new interval
 - Global Home Assistant connection status indicator in the bottom bar, always visible: green when connected, red when disconnected or not configured. Clicking it opens a popover with the per-service status detail and a button to jump straight to the Home Assistant settings (the External Services page lands pre-filtered on the relevant adapter) (#20).
 - Unit-of-measure fields in configuration forms are now selected through a segmented control (e.g. `W` / `kW` / `MW`, `Wh` / `kWh` / `MWh`, `GH/s` / `TH/s` / `PH/s`) instead of a free-text input, preventing inconsistent or invalid values. The available options are inferred automatically from each field, so the control applies to every configuration form (#18).
 - Home Assistant entity fields now show a selectable entity-domain prefix (e.g. `sensor.`, `switch.`) as a dropdown next to the input, so the user only types the entity object id. The domain defaults to the one derived from the field's value/default/name and can be overridden, with the prefix now enabled on Forecast Provider and Miner Controller forms too (handling controllers that mix `switch.` and `sensor.` entities) (#39).
@@ -46,6 +51,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Miner controller add/edit form now uses the shared schema-driven configuration form, so Home Assistant controllers (e.g. generic socket) benefit from entity/unit pairing and the unit segmented controls like the other forms (#17, #18).
 - Cleaned up sidebar header: removed the "Edge Mining" text label and the username placeholder, left-aligned the logo with the sidebar menu items, and refined the green glow to originate from the logo area (#33).
 - `MinerActionService`: extracted shared `_read_miner_info` / `_read_miner_limits`helpers and a `_temp_miner_for_controller` builder, reused by the miner- and controller-level info/limits/details reads.
+- System configuration (timezone, latitude, longitude, scheduler interval) now lives in the database and is managed from the app; the values are seeded from defaults on first run.
+
+### Removed
+
+- Environment variables `TIMEZONE`, `LATITUDE`, `LONGITUDE` and `SCHEDULER_INTERVAL_SECONDS` are no longer read; these settings are now managed from the System settings page. Existing values in `.env` are ignored.
 
 ## [Pre-Release Rev3]
 

--- a/core/edge_mining/__main__.py
+++ b/core/edge_mining/__main__.py
@@ -73,6 +73,8 @@ async def main_async():
             optimization_service=services.optimization_service,
             logger=logger,
             settings=settings,
+            system_configuration=services.configuration_service.get_system_configuration(),
+            event_bus=services.event_bus,
             home_load_history_service=services.home_load_history_service,
             load_forecast_training_service=services.load_forecast_training_service,
         )

--- a/core/edge_mining/adapters/domain/user/fast_api/__init__.py
+++ b/core/edge_mining/adapters/domain/user/fast_api/__init__.py
@@ -1,0 +1,1 @@
+"""FastAPI adapters for the user/system settings domain."""

--- a/core/edge_mining/adapters/domain/user/fast_api/router.py
+++ b/core/edge_mining/adapters/domain/user/fast_api/router.py
@@ -1,0 +1,39 @@
+"""API Router for the system settings domain."""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from edge_mining.adapters.domain.user.schemas import SystemConfigurationSchema
+from edge_mining.adapters.infrastructure.api.setup import get_config_service
+from edge_mining.application.interfaces import ConfigurationServiceInterface
+from edge_mining.domain.exceptions import ConfigurationError
+
+router = APIRouter()
+
+
+@router.get("/system/settings", response_model=SystemConfigurationSchema)
+async def get_system_settings(
+    config_service: Annotated[ConfigurationServiceInterface, Depends(get_config_service)],
+) -> SystemConfigurationSchema:
+    """Get the current system configuration."""
+    try:
+        configuration = config_service.get_system_configuration()
+        return SystemConfigurationSchema.from_model(configuration)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.put("/system/settings", response_model=SystemConfigurationSchema)
+async def update_system_settings(
+    payload: SystemConfigurationSchema,
+    config_service: Annotated[ConfigurationServiceInterface, Depends(get_config_service)],
+) -> SystemConfigurationSchema:
+    """Update the system configuration."""
+    try:
+        configuration = await config_service.update_system_configuration(payload.to_model())
+        return SystemConfigurationSchema.from_model(configuration)
+    except ConfigurationError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e

--- a/core/edge_mining/adapters/domain/user/schemas.py
+++ b/core/edge_mining/adapters/domain/user/schemas.py
@@ -1,0 +1,47 @@
+"""Validation schemas for the user/system settings domain."""
+
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from pydantic import BaseModel, Field, field_validator
+
+from edge_mining.domain.user.value_objects import SystemConfiguration
+
+
+class SystemConfigurationSchema(BaseModel):
+    """Schema for the user-editable system configuration."""
+
+    timezone: str = Field(default="Europe/Rome", description="IANA timezone name (e.g. Europe/Rome)")
+    latitude: float = Field(default=41.9028, ge=-90.0, le=90.0, description="Location latitude in degrees")
+    longitude: float = Field(default=12.4964, ge=-180.0, le=180.0, description="Location longitude in degrees")
+    scheduler_interval_seconds: int = Field(
+        default=5, ge=1, description="Interval in seconds between optimization evaluations"
+    )
+
+    @field_validator("timezone")
+    @classmethod
+    def validate_timezone(cls, v: str) -> str:
+        """Validate that the timezone is a known IANA timezone."""
+        try:
+            ZoneInfo(v)
+        except (ZoneInfoNotFoundError, ValueError) as exc:
+            raise ValueError(f"'{v}' is not a valid IANA timezone") from exc
+        return v
+
+    @classmethod
+    def from_model(cls, configuration: SystemConfiguration) -> "SystemConfigurationSchema":
+        """Build the schema from a domain configuration."""
+        return cls(
+            timezone=configuration.timezone,
+            latitude=configuration.latitude,
+            longitude=configuration.longitude,
+            scheduler_interval_seconds=configuration.scheduler_interval_seconds,
+        )
+
+    def to_model(self) -> SystemConfiguration:
+        """Convert the schema into a domain configuration."""
+        return SystemConfiguration(
+            timezone=self.timezone,
+            latitude=self.latitude,
+            longitude=self.longitude,
+            scheduler_interval_seconds=self.scheduler_interval_seconds,
+        )

--- a/core/edge_mining/adapters/infrastructure/api/main_api.py
+++ b/core/edge_mining/adapters/infrastructure/api/main_api.py
@@ -16,6 +16,7 @@ from edge_mining.adapters.domain.notification.fast_api.router import router as n
 from edge_mining.adapters.domain.optimization_unit.fast_api.router import router as optimization_unit_router
 from edge_mining.adapters.domain.performance.fast_api.router import router as performance_router
 from edge_mining.adapters.domain.policy.fast_api.router import router as policy_router
+from edge_mining.adapters.domain.user.fast_api.router import router as system_router
 
 # Import dependency injection setup functions
 from edge_mining.adapters.infrastructure.api.setup import get_logger, get_optimization_service, get_service_container
@@ -86,6 +87,7 @@ app.include_router(forecast_router, prefix="/api/v1", tags=["forecast"])
 app.include_router(home_load_router, prefix="/api/v1", tags=["home_load"])
 app.include_router(performance_router, prefix="/api/v1", tags=["performance"])
 app.include_router(climate_router, prefix="/api/v1", tags=["climate"])
+app.include_router(system_router, prefix="/api/v1", tags=["system"])
 app.include_router(ws_router, tags=["websocket"])
 # Add more routers here (e.g., for configuration)
 

--- a/core/edge_mining/adapters/infrastructure/sheduler/jobs.py
+++ b/core/edge_mining/adapters/infrastructure/sheduler/jobs.py
@@ -4,8 +4,14 @@ from typing import Optional
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
-from edge_mining.application.interfaces import HomeLoadHistoryServiceInterface, OptimizationServiceInterface
+from edge_mining.application.interfaces import (
+    EventBusInterface,
+    HomeLoadHistoryServiceInterface,
+    OptimizationServiceInterface,
+)
 from edge_mining.application.services.load_forecast_training_service import LoadForecastModelTrainingService
+from edge_mining.domain.user.events import SystemConfigurationUpdated
+from edge_mining.domain.user.value_objects import SystemConfiguration
 from edge_mining.shared.logging.port import LoggerPort
 from edge_mining.shared.scheduler.port import SchedulerPort
 from edge_mining.shared.settings.settings import AppSettings
@@ -19,6 +25,8 @@ class AutomationScheduler(SchedulerPort):
         optimization_service: OptimizationServiceInterface,
         logger: LoggerPort,
         settings: AppSettings,
+        system_configuration: SystemConfiguration,
+        event_bus: EventBusInterface,
         home_load_history_service: Optional[HomeLoadHistoryServiceInterface] = None,
         load_forecast_training_service: Optional[LoadForecastModelTrainingService] = None,
     ):
@@ -27,12 +35,19 @@ class AutomationScheduler(SchedulerPort):
         self.load_forecast_training_service = load_forecast_training_service
         self.logger = logger
         self.settings = settings
-        self.scheduler = AsyncIOScheduler(timezone=self.settings.timezone)
+        self._interval_seconds = system_configuration.scheduler_interval_seconds
+        self.scheduler = AsyncIOScheduler(timezone=system_configuration.timezone)
 
         self._job_id = "evaluate_mining"
         self._history_collect_job_id = "collect_load_history"
         self._history_purge_job_id = "purge_load_history"
         self._model_training_job_id = "train_load_forecast_models"
+
+        event_bus.subscribe(
+            SystemConfigurationUpdated,
+            self.on_system_configuration_updated,
+            blocking=False,
+        )
 
     async def _run_evaluation_job(self):
         """Wrapper to call the optimization service's run method."""
@@ -74,9 +89,22 @@ class AutomationScheduler(SchedulerPort):
         except Exception as e:
             self.logger.error(f"Error during scheduled job: {self._model_training_job_id}. {e}")
 
+    async def on_system_configuration_updated(self, event: SystemConfigurationUpdated) -> None:
+        """Reschedule the evaluation job when the scheduler interval changes."""
+        configuration = event.configuration
+        if configuration is None:
+            return
+
+        interval = configuration.scheduler_interval_seconds
+        self._interval_seconds = interval
+
+        if self.scheduler.get_job(self._job_id):
+            self.scheduler.reschedule_job(self._job_id, trigger="interval", seconds=interval)
+            self.logger.debug(f"Rescheduled job |{self._job_id}| to run every {interval} seconds.")
+
     async def start(self):
         """Adds the job and starts the scheduler."""
-        interval = self.settings.scheduler_interval_seconds
+        interval = self._interval_seconds
         self.logger.debug(f"Starting scheduler. job |{self._job_id}| will run every {interval} seconds.")
 
         self.scheduler.add_job(

--- a/core/edge_mining/adapters/infrastructure/sun/factories.py
+++ b/core/edge_mining/adapters/infrastructure/sun/factories.py
@@ -34,6 +34,16 @@ class AstralSunFactory(SunFactoryInterface):
         )
         self._location = location_info
 
+    def reconfigure(self, latitude: float, longitude: float, timezone: str) -> None:
+        """Update the location used to compute Sun objects, preserving name and region."""
+        self._location = LocationInfo(
+            name=self._location.name,
+            region=self._location.region,
+            timezone=timezone,
+            latitude=latitude,
+            longitude=longitude,
+        )
+
     def create_sun_for_date(self, for_date: datetime = datetime.now()) -> Sun:
         """
         Creates a Sun object for a specific date.

--- a/core/edge_mining/adapters/infrastructure/system/__init__.py
+++ b/core/edge_mining/adapters/infrastructure/system/__init__.py
@@ -1,0 +1,1 @@
+"""System configuration infrastructure adapters."""

--- a/core/edge_mining/adapters/infrastructure/system/handlers.py
+++ b/core/edge_mining/adapters/infrastructure/system/handlers.py
@@ -1,0 +1,42 @@
+"""Event handlers that apply system configuration changes to ambient infrastructure."""
+
+from edge_mining.application.interfaces import EventBusInterface, SunFactoryInterface
+from edge_mining.domain.user.events import SystemConfigurationUpdated
+from edge_mining.shared.logging.port import LoggerPort
+from edge_mining.shared.timezone import set_timezone
+
+
+class SystemConfigurationHandler:
+    """Applies runtime system configuration changes to ambient infrastructure.
+
+    Reacts to ``SystemConfigurationUpdated`` events by refreshing the application
+    timezone and reconfiguring the Sun factory location, so that changes take
+    effect without restarting the application.
+    """
+
+    def __init__(self, sun_factory: SunFactoryInterface, logger: LoggerPort) -> None:
+        self._sun_factory = sun_factory
+        self._logger = logger
+
+    def subscribe(self, event_bus: EventBusInterface) -> None:
+        """Register this handler on the event bus."""
+        event_bus.subscribe(
+            SystemConfigurationUpdated,
+            self.on_system_configuration_updated,
+            blocking=False,
+        )
+
+    async def on_system_configuration_updated(self, event: SystemConfigurationUpdated) -> None:
+        """Apply the updated system configuration to the ambient infrastructure."""
+        configuration = event.configuration
+        if configuration is None:
+            return
+
+        self._logger.debug("Applying updated system configuration to ambient infrastructure.")
+
+        set_timezone(configuration.timezone)
+        self._sun_factory.reconfigure(
+            latitude=configuration.latitude,
+            longitude=configuration.longitude,
+            timezone=configuration.timezone,
+        )

--- a/core/edge_mining/application/interfaces.py
+++ b/core/edge_mining/application/interfaces.py
@@ -45,6 +45,7 @@ from edge_mining.domain.policy.common import RuleType
 from edge_mining.domain.policy.entities import AutomationRule
 from edge_mining.domain.policy.services import RuleEngine
 from edge_mining.domain.policy.value_objects import DecisionalContext, Sun
+from edge_mining.domain.user.value_objects import SystemConfiguration
 from edge_mining.shared.external_services.common import ExternalServiceAdapter
 from edge_mining.shared.external_services.entities import ExternalService
 from edge_mining.shared.external_services.ports import ExternalServicePort
@@ -1034,6 +1035,14 @@ class ConfigurationServiceInterface(ABC):
     async def update_setting(self, key: str, value: Any) -> None:
         """Update a setting."""
 
+    @abstractmethod
+    def get_system_configuration(self) -> SystemConfiguration:
+        """Get the current system configuration."""
+
+    @abstractmethod
+    async def update_system_configuration(self, configuration: SystemConfiguration) -> SystemConfiguration:
+        """Validate, persist and broadcast the system configuration."""
+
     # --- Climate Zone Management ---
 
     @abstractmethod
@@ -1133,6 +1142,10 @@ class SunFactoryInterface(ABC):
     @abstractmethod
     def create_sun_for_date(self, for_date: datetime = datetime.now()) -> Sun:
         """Create a Sun object for a specific date."""
+
+    @abstractmethod
+    def reconfigure(self, latitude: float, longitude: float, timezone: str) -> None:
+        """Update the location used to compute Sun objects."""
 
 
 class EventBusInterface(ABC):

--- a/core/edge_mining/application/services/configuration_service.py
+++ b/core/edge_mining/application/services/configuration_service.py
@@ -2555,8 +2555,7 @@ class ConfigurationService(ConfigurationServiceInterface):
 
         if configuration.scheduler_interval_seconds < 1:
             raise ConfigurationError(
-                f"Invalid scheduler interval '{configuration.scheduler_interval_seconds}': "
-                "must be at least 1 second."
+                f"Invalid scheduler interval '{configuration.scheduler_interval_seconds}': must be at least 1 second."
             )
 
     # --- Climate Zone Management ---

--- a/core/edge_mining/application/services/configuration_service.py
+++ b/core/edge_mining/application/services/configuration_service.py
@@ -3,6 +3,7 @@ Configuration service for managing all domain entities of edge mining applicatio
 """
 
 from typing import Any, Dict, List, Optional
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from edge_mining.application.events.common import (
     ConfigurationAction,
@@ -84,10 +85,13 @@ from edge_mining.domain.policy.exceptions import (
     PolicyNotFoundError,
     RuleNotFoundError,
 )
+from edge_mining.domain.exceptions import ConfigurationError
 from edge_mining.domain.policy.ports import OptimizationPolicyRepository
 from edge_mining.domain.policy.services import RuleValidationService
 from edge_mining.domain.user.common import UserId
 from edge_mining.domain.user.entities import SystemSettings
+from edge_mining.domain.user.events import SystemConfigurationUpdated
+from edge_mining.domain.user.value_objects import SystemConfiguration
 from edge_mining.shared.adapter_maps.energy import (
     ENERGY_MONITOR_CONFIG_TYPE_MAP,
     ENERGY_MONITOR_TYPE_EXTERNAL_SERVICE_MAP,
@@ -2499,6 +2503,61 @@ class ConfigurationService(ConfigurationServiceInterface):
         settings.set_setting(key, value)
 
         self.settings_repo.save_settings(user_id, settings)
+
+    def get_system_configuration(self) -> SystemConfiguration:
+        """Get the current system configuration, falling back to defaults for missing values."""
+        stored = self.get_all_settings()
+        defaults = SystemConfiguration()
+        return SystemConfiguration(
+            timezone=stored.get("timezone", defaults.timezone),
+            latitude=float(stored.get("latitude", defaults.latitude)),
+            longitude=float(stored.get("longitude", defaults.longitude)),
+            scheduler_interval_seconds=int(
+                stored.get("scheduler_interval_seconds", defaults.scheduler_interval_seconds)
+            ),
+        )
+
+    async def update_system_configuration(self, configuration: SystemConfiguration) -> SystemConfiguration:
+        """Validate, persist and broadcast the system configuration."""
+        self._validate_system_configuration(configuration)
+
+        user_id: UserId = UserId("global_settings")
+        settings = self.settings_repo.get_settings(user_id)
+        if not settings:
+            settings = SystemSettings(id=user_id)
+
+        self.logger.info("Updating system configuration.")
+
+        settings.set_setting("timezone", configuration.timezone)
+        settings.set_setting("latitude", configuration.latitude)
+        settings.set_setting("longitude", configuration.longitude)
+        settings.set_setting("scheduler_interval_seconds", configuration.scheduler_interval_seconds)
+
+        self.settings_repo.save_settings(user_id, settings)
+
+        await self._event_bus.publish(SystemConfigurationUpdated(configuration=configuration))
+
+        return configuration
+
+    @staticmethod
+    def _validate_system_configuration(configuration: SystemConfiguration) -> None:
+        """Validate the values of a system configuration, raising ConfigurationError if invalid."""
+        try:
+            ZoneInfo(configuration.timezone)
+        except (ZoneInfoNotFoundError, ValueError) as e:
+            raise ConfigurationError(f"Invalid timezone '{configuration.timezone}'.") from e
+
+        if not -90.0 <= configuration.latitude <= 90.0:
+            raise ConfigurationError(f"Invalid latitude '{configuration.latitude}': must be between -90 and 90.")
+
+        if not -180.0 <= configuration.longitude <= 180.0:
+            raise ConfigurationError(f"Invalid longitude '{configuration.longitude}': must be between -180 and 180.")
+
+        if configuration.scheduler_interval_seconds < 1:
+            raise ConfigurationError(
+                f"Invalid scheduler interval '{configuration.scheduler_interval_seconds}': "
+                "must be at least 1 second."
+            )
 
     # --- Climate Zone Management ---
 

--- a/core/edge_mining/bootstrap.py
+++ b/core/edge_mining/bootstrap.py
@@ -82,6 +82,7 @@ from edge_mining.adapters.infrastructure.persistence.sqlalchemy.base import Base
 from edge_mining.adapters.infrastructure.persistence.sqlite import BaseSqliteRepository
 from edge_mining.adapters.infrastructure.event_bus.in_memory_event_bus import InMemoryEventBus
 from edge_mining.adapters.infrastructure.sun.factories import AstralSunFactory
+from edge_mining.adapters.infrastructure.system.handlers import SystemConfigurationHandler
 from edge_mining.application.interfaces import SunFactoryInterface
 from edge_mining.application.services.adapter_service import AdapterService
 from edge_mining.application.services.configuration_service import ConfigurationService
@@ -112,6 +113,7 @@ from edge_mining.shared.logging.port import LoggerPort
 from edge_mining.shared.settings.common import PersistenceAdapter
 from edge_mining.shared.settings.ports import SettingsRepository
 from edge_mining.shared.settings.settings import AppSettings
+from edge_mining.shared.timezone import set_timezone
 
 
 def configure_persistence(logger: LoggerPort, settings: AppSettings) -> PersistenceSettings:
@@ -322,13 +324,6 @@ def configure_dependencies(logger: LoggerPort, settings: AppSettings) -> Service
 
     logger.debug("Configuring dependencies...")
 
-    # --- Factories ---
-    sun_factory: SunFactoryInterface = AstralSunFactory(
-        latitude=settings.latitude,
-        longitude=settings.longitude,
-        timezone=settings.timezone,
-    )
-
     # --- Persistence ---
     persistence_settings: PersistenceSettings = configure_persistence(logger, settings)
 
@@ -354,6 +349,30 @@ def configure_dependencies(logger: LoggerPort, settings: AppSettings) -> Service
         climate_monitor_repo=persistence_settings.climate_monitor_repo,
     )
 
+    config_service = ConfigurationService(
+        persistence_settings=persistence_settings,
+        event_bus=event_bus,
+        logger=logger,
+        adapter_service=adapter_service,
+    )
+
+    # --- System configuration (timezone, location) ---
+    system_configuration = config_service.get_system_configuration()
+
+    # Apply the configured timezone application-wide
+    set_timezone(system_configuration.timezone)
+
+    # --- Factories ---
+    sun_factory: SunFactoryInterface = AstralSunFactory(
+        latitude=system_configuration.latitude,
+        longitude=system_configuration.longitude,
+        timezone=system_configuration.timezone,
+    )
+
+    # Apply system configuration changes to ambient infrastructure at runtime
+    system_configuration_handler = SystemConfigurationHandler(sun_factory=sun_factory, logger=logger)
+    system_configuration_handler.subscribe(event_bus)
+
     optimization_service = OptimizationService(
         optimization_unit_repo=persistence_settings.optimization_unit_repo,
         energy_source_repo=persistence_settings.energy_source_repo,
@@ -374,13 +393,6 @@ def configure_dependencies(logger: LoggerPort, settings: AppSettings) -> Service
         miner_repo=persistence_settings.miner_repo,
         event_bus=event_bus,
         logger=logger,
-    )
-
-    config_service = ConfigurationService(
-        persistence_settings=persistence_settings,
-        event_bus=event_bus,
-        logger=logger,
-        adapter_service=adapter_service,
     )
 
     home_load_history_service = HomeLoadHistoryService(

--- a/core/edge_mining/domain/user/events.py
+++ b/core/edge_mining/domain/user/events.py
@@ -1,0 +1,14 @@
+"""User Settings domain events."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from edge_mining.domain.common import DomainEvent
+from edge_mining.domain.user.value_objects import SystemConfiguration
+
+
+@dataclass
+class SystemConfigurationUpdated(DomainEvent):
+    """Event emitted when the user-editable system configuration is updated."""
+
+    configuration: Optional[SystemConfiguration] = None

--- a/core/edge_mining/domain/user/value_objects.py
+++ b/core/edge_mining/domain/user/value_objects.py
@@ -1,0 +1,15 @@
+"""Collection of Value Objects for the User Settings domain of the Edge Mining application."""
+
+from dataclasses import dataclass
+
+from edge_mining.domain.common import ValueObject
+
+
+@dataclass(frozen=True)
+class SystemConfiguration(ValueObject):
+    """Value Object for the user-editable system configuration."""
+
+    timezone: str = "Europe/Rome"
+    latitude: float = 41.9028  # Rome
+    longitude: float = 12.4964  # Rome
+    scheduler_interval_seconds: int = 5

--- a/core/edge_mining/shared/settings/settings.py
+++ b/core/edge_mining/shared/settings/settings.py
@@ -10,9 +10,6 @@ class AppSettings(BaseSettings):
 
     # Application settings
     log_level: str = "INFO"
-    timezone: str = "Europe/Rome"  # Default timezone
-    latitude: float = 41.9028  # Default latitude for Rome
-    longitude: float = 12.4964  # Default longitude for Rome
 
     # Adapters Configuration (select which ones to use)
     persistence_adapter: str = "sqlalchemy"  # Options: "in_memory", "sqlite", "yaml", "sqlalchemy"
@@ -30,7 +27,6 @@ class AppSettings(BaseSettings):
     api_port: int = 8001
 
     # Scheduler settings
-    scheduler_interval_seconds: int = 5  # Evaluate every 5 seconds
     history_ingestion_interval_seconds: int = 120  # Collect power points every 2 minutes
     history_retention_days: int = 90  # Purge power points older than 90 days
 

--- a/core/edge_mining/shared/timezone.py
+++ b/core/edge_mining/shared/timezone.py
@@ -1,16 +1,44 @@
 """Timezone utility for the Edge Mining application."""
 
 from datetime import datetime
-from functools import lru_cache
+from typing import Optional
 from zoneinfo import ZoneInfo
 
-from edge_mining.shared.settings.settings import AppSettings
+
+class TimezoneProvider:
+    """Holds the application-wide timezone and caches the resolved ZoneInfo.
+
+    Seeded at startup from the persisted system configuration and updated at
+    runtime when the configuration changes.
+    """
+
+    def __init__(self, timezone: str = "Europe/Rome") -> None:
+        self._timezone_name = timezone
+        self._cached_zone: Optional[ZoneInfo] = None
+
+    def set_timezone(self, timezone: str) -> None:
+        """Set the timezone and invalidate the cached zone."""
+        self._timezone_name = timezone
+        self._cached_zone = None
+
+    def get_timezone(self) -> ZoneInfo:
+        """Get the configured timezone, resolving and caching it on first use."""
+        if self._cached_zone is None:
+            self._cached_zone = ZoneInfo(self._timezone_name)
+        return self._cached_zone
 
 
-@lru_cache(maxsize=1)
+_provider = TimezoneProvider()
+
+
+def set_timezone(timezone: str) -> None:
+    """Set the application's timezone."""
+    _provider.set_timezone(timezone)
+
+
 def get_timezone() -> ZoneInfo:
     """Get the application's configured timezone."""
-    return ZoneInfo(AppSettings().timezone)
+    return _provider.get_timezone()
 
 
 def now() -> datetime:

--- a/core/tests/unit/adapters/domain/user/test_schemas.py
+++ b/core/tests/unit/adapters/domain/user/test_schemas.py
@@ -1,0 +1,54 @@
+"""Unit tests for the system settings Pydantic schemas."""
+
+import pytest
+from pydantic import ValidationError
+
+from edge_mining.adapters.domain.user.schemas import SystemConfigurationSchema
+from edge_mining.domain.user.value_objects import SystemConfiguration
+
+
+class TestSystemConfigurationSchema:
+    """Tests for SystemConfiguration schema round-trips and validation."""
+
+    def test_from_model(self):
+        config = SystemConfiguration(
+            timezone="America/New_York",
+            latitude=40.0,
+            longitude=-74.0,
+            scheduler_interval_seconds=15,
+        )
+        schema = SystemConfigurationSchema.from_model(config)
+        assert schema.timezone == "America/New_York"
+        assert schema.latitude == 40.0
+        assert schema.longitude == -74.0
+        assert schema.scheduler_interval_seconds == 15
+
+    def test_to_model(self):
+        schema = SystemConfigurationSchema(
+            timezone="Europe/Rome",
+            latitude=41.9028,
+            longitude=12.4964,
+            scheduler_interval_seconds=5,
+        )
+        model = schema.to_model()
+        assert isinstance(model, SystemConfiguration)
+        assert model.timezone == "Europe/Rome"
+        assert model.scheduler_interval_seconds == 5
+
+    def test_invalid_timezone_is_rejected(self):
+        with pytest.raises(ValidationError):
+            SystemConfigurationSchema(timezone="Not/AZone")
+
+    @pytest.mark.parametrize("latitude", [-91.0, 91.0])
+    def test_out_of_range_latitude_is_rejected(self, latitude):
+        with pytest.raises(ValidationError):
+            SystemConfigurationSchema(latitude=latitude)
+
+    @pytest.mark.parametrize("longitude", [-181.0, 181.0])
+    def test_out_of_range_longitude_is_rejected(self, longitude):
+        with pytest.raises(ValidationError):
+            SystemConfigurationSchema(longitude=longitude)
+
+    def test_non_positive_interval_is_rejected(self):
+        with pytest.raises(ValidationError):
+            SystemConfigurationSchema(scheduler_interval_seconds=0)

--- a/core/tests/unit/adapters/infrastructure/system/test_handlers.py
+++ b/core/tests/unit/adapters/infrastructure/system/test_handlers.py
@@ -1,0 +1,39 @@
+"""Unit tests for the SystemConfigurationHandler."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from edge_mining.adapters.infrastructure.system.handlers import SystemConfigurationHandler
+from edge_mining.domain.user.events import SystemConfigurationUpdated
+from edge_mining.domain.user.value_objects import SystemConfiguration
+from edge_mining.shared import timezone as tz
+
+
+@pytest.mark.asyncio
+async def test_applies_timezone_and_reconfigures_sun_factory():
+    sun_factory = MagicMock()
+    handler = SystemConfigurationHandler(sun_factory=sun_factory, logger=MagicMock())
+
+    tz.set_timezone("UTC")
+    config = SystemConfiguration(
+        timezone="America/New_York",
+        latitude=40.0,
+        longitude=-74.0,
+        scheduler_interval_seconds=15,
+    )
+
+    await handler.on_system_configuration_updated(SystemConfigurationUpdated(configuration=config))
+
+    assert str(tz.get_timezone()) == "America/New_York"
+    sun_factory.reconfigure.assert_called_once_with(latitude=40.0, longitude=-74.0, timezone="America/New_York")
+
+
+@pytest.mark.asyncio
+async def test_ignores_event_without_configuration():
+    sun_factory = MagicMock()
+    handler = SystemConfigurationHandler(sun_factory=sun_factory, logger=MagicMock())
+
+    await handler.on_system_configuration_updated(SystemConfigurationUpdated(configuration=None))
+
+    sun_factory.reconfigure.assert_not_called()

--- a/core/tests/unit/application/services/test_system_configuration.py
+++ b/core/tests/unit/application/services/test_system_configuration.py
@@ -1,0 +1,81 @@
+"""Unit tests for the system configuration management in ConfigurationService."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from edge_mining.adapters.domain.user.repositories import InMemorySettingsRepository
+from edge_mining.adapters.infrastructure.event_bus.in_memory_event_bus import InMemoryEventBus
+from edge_mining.application.services.configuration_service import ConfigurationService
+from edge_mining.domain.exceptions import ConfigurationError
+from edge_mining.domain.user.events import SystemConfigurationUpdated
+from edge_mining.domain.user.value_objects import SystemConfiguration
+
+
+@pytest.fixture
+def logger():
+    return MagicMock()
+
+
+@pytest.fixture
+def event_bus(logger):
+    return InMemoryEventBus(logger)
+
+
+@pytest.fixture
+def config_service(logger, event_bus):
+    persistence = MagicMock()
+    persistence.settings_repo = InMemorySettingsRepository()
+    return ConfigurationService(persistence_settings=persistence, event_bus=event_bus, logger=logger)
+
+
+class TestGetSystemConfiguration:
+    def test_returns_defaults_when_empty(self, config_service):
+        config = config_service.get_system_configuration()
+        assert config == SystemConfiguration()
+
+
+class TestUpdateSystemConfiguration:
+    @pytest.mark.asyncio
+    async def test_persists_and_returns_configuration(self, config_service):
+        new_config = SystemConfiguration(
+            timezone="America/New_York",
+            latitude=40.0,
+            longitude=-74.0,
+            scheduler_interval_seconds=15,
+        )
+        result = await config_service.update_system_configuration(new_config)
+
+        assert result == new_config
+        assert config_service.get_system_configuration() == new_config
+
+    @pytest.mark.asyncio
+    async def test_publishes_event(self, config_service, event_bus):
+        received = []
+
+        async def collect(event: SystemConfigurationUpdated) -> None:
+            received.append(event)
+
+        event_bus.subscribe(SystemConfigurationUpdated, collect, blocking=True)
+
+        new_config = SystemConfiguration(timezone="UTC", scheduler_interval_seconds=30)
+        await config_service.update_system_configuration(new_config)
+
+        assert len(received) == 1
+        assert received[0].configuration == new_config
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_timezone(self, config_service):
+        with pytest.raises(ConfigurationError):
+            await config_service.update_system_configuration(SystemConfiguration(timezone="Not/AZone"))
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("latitude", [-91.0, 91.0])
+    async def test_rejects_out_of_range_latitude(self, config_service, latitude):
+        with pytest.raises(ConfigurationError):
+            await config_service.update_system_configuration(SystemConfiguration(latitude=latitude))
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_positive_interval(self, config_service):
+        with pytest.raises(ConfigurationError):
+            await config_service.update_system_configuration(SystemConfiguration(scheduler_interval_seconds=0))

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@vue-flow/core": "^1.48.1",
         "apexcharts": "^5.10.4",
         "axios": "^1.11.0",
+        "leaflet": "^1.9.4",
         "pinia": "^3.0.3",
         "tailwindcss": "^4.1.12",
         "vue": "^3.5.18",
@@ -23,6 +24,7 @@
         "vue3-apexcharts": "^1.11.1"
       },
       "devDependencies": {
+        "@types/leaflet": "^1.9.21",
         "@vitejs/plugin-vue": "^6.0.1",
         "@vue/tsconfig": "^0.7.0",
         "daisyui": "^5.0.50",
@@ -1161,6 +1163,23 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.21",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
+      "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -2101,6 +2120,12 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
+    },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/lightningcss": {
       "version": "1.30.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "@vue-flow/core": "^1.48.1",
     "apexcharts": "^5.10.4",
     "axios": "^1.11.0",
+    "leaflet": "^1.9.4",
     "pinia": "^3.0.3",
     "tailwindcss": "^4.1.12",
     "vue": "^3.5.18",
@@ -24,6 +25,7 @@
     "vue3-apexcharts": "^1.11.1"
   },
   "devDependencies": {
+    "@types/leaflet": "^1.9.21",
     "@vitejs/plugin-vue": "^6.0.1",
     "@vue/tsconfig": "^0.7.0",
     "daisyui": "^5.0.50",

--- a/frontend/src/components/LocationMapPicker.vue
+++ b/frontend/src/components/LocationMapPicker.vue
@@ -1,0 +1,134 @@
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref, watch } from "vue";
+import L from "leaflet";
+import "leaflet/dist/leaflet.css";
+
+const latitude = defineModel<number>("latitude", { required: true });
+const longitude = defineModel<number>("longitude", { required: true });
+
+const mapContainer = ref<HTMLElement | null>(null);
+
+let map: L.Map | null = null;
+let marker: L.Marker | null = null;
+// Guards updates coming from the map itself, to avoid a watch feedback loop.
+let updatingFromMap = false;
+
+// Edge Mining logo mark (from VectorIcon.vue), used as the map marker.
+const BRAND_COLOR = "#BEFFA3";
+const logoSvg = `<svg width="22" height="22" viewBox="0 0 46 46" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M31.825 13.917L43.6549 2.08496M2.085 13.917L13.915 2.08496M31.805 13.952V43.705M31.835 13.923H2.085M31.825 43.653L43.6549 31.821" stroke="${BRAND_COLOR}" stroke-width="4.17" stroke-miterlimit="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>`;
+
+const markerIcon = L.divIcon({
+  className: "em-map-marker",
+  iconSize: [40, 48],
+  iconAnchor: [20, 48],
+  popupAnchor: [0, -48],
+  html: `
+    <div style="position:relative;width:40px;height:48px;">
+      <div style="position:absolute;top:0;left:0;width:40px;height:40px;border-radius:9999px;background:#171717;border:2px solid ${BRAND_COLOR};box-shadow:0 2px 6px rgba(0,0,0,.5);display:flex;align-items:center;justify-content:center;">
+        ${logoSvg}
+      </div>
+      <div style="position:absolute;left:50%;bottom:0;transform:translateX(-50%);width:0;height:0;border-left:7px solid transparent;border-right:7px solid transparent;border-top:10px solid ${BRAND_COLOR};"></div>
+    </div>
+  `,
+});
+
+function round(value: number): number {
+  return Math.round(value * 1e6) / 1e6;
+}
+
+function setCoordinates(lat: number, lng: number) {
+  updatingFromMap = true;
+  latitude.value = round(lat);
+  longitude.value = round(lng);
+  updatingFromMap = false;
+}
+
+onMounted(() => {
+  if (!mapContainer.value) return;
+
+  const lat = latitude.value ?? 0;
+  const lng = longitude.value ?? 0;
+
+  map = L.map(mapContainer.value, { attributionControl: true }).setView([lat, lng], 6);
+
+  L.tileLayer(
+    "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png",
+    {
+      attribution:
+        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+      subdomains: "abcd",
+      maxZoom: 20,
+    }
+  ).addTo(map);
+
+  marker = L.marker([lat, lng], { draggable: true, icon: markerIcon }).addTo(map);
+
+  marker.on("dragend", () => {
+    if (!marker) return;
+    const { lat: mLat, lng: mLng } = marker.getLatLng();
+    setCoordinates(mLat, mLng);
+  });
+
+  map.on("click", (event: L.LeafletMouseEvent) => {
+    marker?.setLatLng(event.latlng);
+    setCoordinates(event.latlng.lat, event.latlng.lng);
+  });
+
+  // The container may be laid out after mount; recompute the size.
+  setTimeout(() => map?.invalidateSize(), 0);
+});
+
+// Keep the marker in sync when the coordinates change from outside (e.g. loaded from the store).
+watch([latitude, longitude], ([lat, lng]) => {
+  if (updatingFromMap || !map || !marker || lat === undefined || lng === undefined) return;
+  marker.setLatLng([lat, lng]);
+  map.panTo([lat, lng]);
+});
+
+onBeforeUnmount(() => {
+  map?.remove();
+  map = null;
+  marker = null;
+});
+</script>
+
+<template>
+  <div class="space-y-2">
+    <div
+      ref="mapContainer"
+      class="h-72 w-full rounded-xl border border-base-300/40 overflow-hidden bg-neutral-900 z-0"
+    ></div>
+    <p class="text-sm text-base-content/60">
+      Click on the map or drag the marker to set your location ·
+      <span class="font-mono text-base-content/80">
+        {{ latitude?.toFixed(4) }}, {{ longitude?.toFixed(4) }}
+      </span>
+    </p>
+  </div>
+</template>
+
+<style scoped>
+/* Match the dark UI: neutral controls and attribution. */
+:deep(.leaflet-container) {
+  background: #171717;
+}
+
+:deep(.leaflet-control-attribution) {
+  background: rgba(0, 0, 0, 0.6);
+  color: rgba(255, 255, 255, 0.6);
+}
+
+:deep(.leaflet-control-attribution a) {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+:deep(.leaflet-bar a) {
+  background-color: #262626;
+  color: #e5e5e5;
+  border-bottom-color: rgba(255, 255, 255, 0.1);
+}
+
+:deep(.leaflet-bar a:hover) {
+  background-color: #333333;
+}
+</style>

--- a/frontend/src/components/SidebarMenu.vue
+++ b/frontend/src/components/SidebarMenu.vue
@@ -10,6 +10,7 @@ import {
   PhGraph,
   PhHouse,
   PhThermometerSimple,
+  PhGearSix,
 } from "@phosphor-icons/vue";
 import VectorIcon from "./VectorIcon.vue";
 
@@ -331,6 +332,18 @@ const isClimateActive = computed(() =>
             >
               <PhBell :size="18" />
               Notifiers
+            </RouterLink>
+          </li>
+
+          <!-- System -->
+          <li class="w-full">
+            <RouterLink
+              to="/settings/system"
+              class="w-full text-sm font-medium"
+              active-class="active text-primary"
+            >
+              <PhGearSix :size="18" />
+              System
             </RouterLink>
           </li>
         </ul>

--- a/frontend/src/core/models/systemConfiguration.ts
+++ b/frontend/src/core/models/systemConfiguration.ts
@@ -1,0 +1,6 @@
+export interface SystemConfiguration {
+  timezone: string;
+  latitude: number;
+  longitude: number;
+  scheduler_interval_seconds: number;
+}

--- a/frontend/src/core/services/systemSettingsService.ts
+++ b/frontend/src/core/services/systemSettingsService.ts
@@ -1,0 +1,14 @@
+import { BaseService } from "./baseService";
+import type { SystemConfiguration } from "../models/systemConfiguration";
+
+export class SystemSettingsService extends BaseService {
+  getSystemConfiguration(): Promise<SystemConfiguration> {
+    return this.get<SystemConfiguration>("/system/settings").getData();
+  }
+
+  updateSystemConfiguration(
+    configuration: SystemConfiguration
+  ): Promise<SystemConfiguration> {
+    return this.put<SystemConfiguration>("/system/settings", configuration).getData();
+  }
+}

--- a/frontend/src/core/stores/systemSettingsStore.ts
+++ b/frontend/src/core/stores/systemSettingsStore.ts
@@ -1,0 +1,32 @@
+import { defineStore } from "pinia";
+import { ref } from "vue";
+import type { SystemConfiguration } from "../models/systemConfiguration";
+import { SystemSettingsService } from "../services/systemSettingsService";
+
+export const useSystemSettingsStore = defineStore("systemSettings", () => {
+  const service = new SystemSettingsService();
+
+  // State
+  const configuration = ref<SystemConfiguration | null>(null);
+
+  // Actions
+  function loadConfiguration() {
+    return service.getSystemConfiguration().then((response) => {
+      configuration.value = response;
+    });
+  }
+
+  function updateConfiguration(config: SystemConfiguration) {
+    return service.updateSystemConfiguration(config).then((response) => {
+      configuration.value = response;
+    });
+  }
+
+  return {
+    // STATE
+    configuration,
+    // ACTIONS
+    loadConfiguration,
+    updateConfiguration,
+  };
+});

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -17,6 +17,7 @@ import HomeLoadsSettingsView from "../views/settings/HomeLoadsSettingsView.vue";
 import HomeLoadsTrainingView from "../views/settings/HomeLoadsTrainingView.vue";
 import ClimateZonesSettingsView from "../views/settings/ClimateZonesSettingsView.vue";
 import ClimateMonitorsSettingsView from "../views/settings/ClimateMonitorsSettingsView.vue";
+import SystemSettingsView from "../views/settings/SystemSettingsView.vue";
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -116,6 +117,11 @@ const router = createRouter({
           path: "climate-monitors",
           name: "settings.climateMonitors",
           component: ClimateMonitorsSettingsView,
+        },
+        {
+          path: "system",
+          name: "settings.system",
+          component: SystemSettingsView,
         },
       ],
     },

--- a/frontend/src/views/settings/SystemSettingsView.vue
+++ b/frontend/src/views/settings/SystemSettingsView.vue
@@ -1,0 +1,139 @@
+<script setup lang="ts">
+import { onMounted, reactive, ref } from "vue";
+import { useSystemSettingsStore } from "../../core/stores/systemSettingsStore";
+import type { SystemConfiguration } from "../../core/models/systemConfiguration";
+import LocationMapPicker from "../../components/LocationMapPicker.vue";
+import {
+  PhClock,
+  PhFloppyDisk,
+  PhGlobeHemisphereWest,
+  PhMapPin,
+} from "@phosphor-icons/vue";
+
+const systemSettingsStore = useSystemSettingsStore();
+
+const loaded = ref(false);
+
+const form = reactive<SystemConfiguration>({
+  timezone: "Europe/Rome",
+  latitude: 41.9028,
+  longitude: 12.4964,
+  scheduler_interval_seconds: 5,
+});
+
+// The list of selectable IANA timezones is provided by the browser.
+const timezones = ref<string[]>([]);
+
+onMounted(async () => {
+  loadTimezones();
+  await systemSettingsStore.loadConfiguration();
+  if (systemSettingsStore.configuration) {
+    Object.assign(form, systemSettingsStore.configuration);
+  }
+  // Make sure the current timezone is always selectable.
+  if (form.timezone && !timezones.value.includes(form.timezone)) {
+    timezones.value = [form.timezone, ...timezones.value];
+  }
+  loaded.value = true;
+});
+
+function loadTimezones() {
+  try {
+    const supported = (Intl as unknown as {
+      supportedValuesOf?: (key: string) => string[];
+    }).supportedValuesOf;
+    timezones.value = supported ? supported("timeZone") : [];
+  } catch {
+    timezones.value = [];
+  }
+}
+
+function handleSave() {
+  systemSettingsStore
+    .updateConfiguration({ ...form })
+    .showToasts("System settings saved", "Failed to save system settings");
+}
+</script>
+
+<template>
+  <div class="card">
+    <div class="card-header">
+      <div>
+        <h1 class="text-2xl font-bold text-base-content">System</h1>
+        <p class="text-sm text-base-content/60 mt-1">
+          Configure timezone, location and the optimization scheduler interval
+        </p>
+      </div>
+    </div>
+    <div class="card-body">
+      <form class="space-y-8 max-w-2xl" @submit.prevent="handleSave">
+        <!-- Time -->
+        <section class="space-y-4">
+          <h2 class="flex items-center gap-2 text-lg font-semibold text-base-content">
+            <PhGlobeHemisphereWest :size="20" class="text-primary" />
+            Time
+          </h2>
+          <div class="form-control">
+            <label class="label mb-1">
+              <span class="label-text font-medium">Timezone</span>
+            </label>
+            <select v-model="form.timezone" class="select select-bordered w-full">
+              <option v-for="tz in timezones" :key="tz" :value="tz">{{ tz }}</option>
+            </select>
+            <label class="label">
+              <span class="label-text-alt text-base-content/50">
+                Used for timestamps and Sun-based calculations
+              </span>
+            </label>
+          </div>
+        </section>
+
+        <!-- Location -->
+        <section class="space-y-4">
+          <h2 class="flex items-center gap-2 text-lg font-semibold text-base-content">
+            <PhMapPin :size="20" class="text-primary" />
+            Location
+          </h2>
+          <LocationMapPicker
+            :latitude="form.latitude"
+            :longitude="form.longitude"
+            @update:latitude="form.latitude = $event"
+            @update:longitude="form.longitude = $event"
+          />
+        </section>
+
+        <!-- Scheduler -->
+        <section class="space-y-4">
+          <h2 class="flex items-center gap-2 text-lg font-semibold text-base-content">
+            <PhClock :size="20" class="text-primary" />
+            Scheduler
+          </h2>
+          <div class="form-control">
+            <label class="label mb-1">
+              <span class="label-text font-medium">Evaluation interval (seconds)</span>
+            </label>
+            <input
+              v-model.number="form.scheduler_interval_seconds"
+              type="number"
+              step="1"
+              min="1"
+              class="input input-bordered w-full sm:max-w-xs"
+            />
+            <label class="label">
+              <span class="label-text-alt text-base-content/50">
+                How often enabled optimization units are evaluated
+              </span>
+            </label>
+          </div>
+        </section>
+
+        <div class="flex justify-end">
+          <button type="submit" class="btn btn-primary gap-2" :disabled="!loaded">
+            <PhFloppyDisk :size="20" weight="bold" />
+            Save
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
Closes #54
Closes #8

## Overview

Move timezone, location (latitude/longitude) and the optimization scheduler interval out of environment variables and into user-editable, database-backed settings, manageable from a new "System" settings page.

## Core

- `SystemConfiguration` value object and `SystemConfigurationUpdated` domain event.
- `ConfigurationService.get_system_configuration()` / `update_system_configuration()` with validation (valid IANA timezone, latitude/longitude ranges, positive interval), persisted through the existing settings store (no migration).
- Runtime propagation via the event bus, no restart needed:
  - refresh the application timezone;
  - reconfigure the Sun-calculation location (`AstralSunFactory.reconfigure()`);
  - reschedule the evaluation job with the new interval.
- Timezone state encapsulated in a `TimezoneProvider`.
- Removed the `TIMEZONE`, `LATITUDE`, `LONGITUDE` and `SCHEDULER_INTERVAL_SECONDS` environment variables; defaults are seeded on first run.

## API

- `GET` / `PUT /api/v1/system/settings`.

## Frontend

- New "System" settings page with the timezone list sourced from the browser and an interactive dark Leaflet map to pick the location (draggable marker using the Edge Mining logo).

## Tests

- Schema, service and handler unit tests. Full unit suite green.

## Notes

- Breaking change: the removed environment variables are ignored; the values now live in the database and are configured from the app.

<img width="1073" height="964" alt="image" src="https://github.com/user-attachments/assets/4af6270a-c24e-4328-8836-a22922873a18" />
